### PR TITLE
Fixed failing npm build on Windows machines

### DIFF
--- a/bashlib/css/package.json
+++ b/bashlib/css/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rm -r dist/; tsc"
+    "build": "rm -rf dist/ && tsc"
   },
   "author": "",
   "license": "ISC",

--- a/bashlib/solid/package.json
+++ b/bashlib/solid/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rm -r dist/ ; tsc"
+    "build": "rm -rf dist/ && tsc"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
OS: Windows 10
CLI: Git Bash
Node version: 16.15.1, most recent LTS at the time of writing

Building bashlib would give errors when deleting, and then not run typescript.
The error was `code ELIFECYCLE, errno 1`.

After trying to do the regular solution (clearing node_modules & cache, reinstalling node & npm...), I've found that modifying the npm build command to not throw errors on rm (rm -rf instead of rm -r), and using the more commonly used && instead of ; were a fix for the issue.

Normally ";" should indeed run the next command, even on error, so this might be a Windows exclusive issue? But more testing would be required for that.