### PR TITLE
Prevent setting invalid contenttype 'false' for PUT request

### DIFF
--- a/src/commands/solid-touch.ts
+++ b/src/commands/solid-touch.ts
@@ -29,7 +29,6 @@ export default async function touch(url: string, options: any) {
               }
             }
         )
-        console.log(res.body)
         if (res.ok) {
             if (verbose) console.log(`Remote file created`)
         }

--- a/src/commands/solid-touch.ts
+++ b/src/commands/solid-touch.ts
@@ -16,7 +16,8 @@ export default async function touch(url: string, options: any) {
     }
     else {
         let path = url.replace(/.*\//,'')
-        let contentType = path.endsWith('.acl') || path.endsWith('.meta') ? 'text/turtle' : mime.lookup(path)
+        let mimetype = mime.lookup(path)
+        let contentType = (path.endsWith('.acl') || path.endsWith('.meta') || !mimetype) ? 'text/turtle' : mimetype
 
         let res = await fetch(
             url, 
@@ -28,6 +29,7 @@ export default async function touch(url: string, options: any) {
               }
             }
         )
+        console.log(res.body)
         if (res.ok) {
             if (verbose) console.log(`Remote file created`)
         }


### PR DESCRIPTION
Result of `mime.lookup(path)` can set the `Content-Type` to `false` resulting in a `400`. This fix sets `text/turtle` as the default contenttype if none can be guessed.