### PR TITLE
fix: ensure config solid directory exists

### DIFF
--- a/src/utils/configoptions.ts
+++ b/src/utils/configoptions.ts
@@ -31,6 +31,9 @@ export type ISessionEntry = {
 }
 
 export function initializeConfig() { 
+  if (!fs.existsSync(SOLIDDIR)) {
+    fs.mkdirSync(SOLIDDIR)
+  }
   if (!fs.existsSync(BASHLIBCONFIGPATH)) { 
     let config: IConfig = {
       currentWebID: undefined,


### PR DESCRIPTION
This creates the solid config directory if it does not exist. Without it I received following error:

```
node:internal/fs/utils:347
    throw err;
    ^

Error: ENOENT: no such file or directory, open '/home/oaie/.solid/.bashlibconfig'
    at Object.openSync (node:fs:600:3)
    at Object.writeFileSync (node:fs:2221:35)
    at initializeConfig (/home/oaie/coding/solid/Bashlib/dist/utils/configoptions.js:51:12)
    at Object.<anonymous> (/home/oaie/coding/solid/Bashlib/bin/solid.js:17:1)
    at Module._compile (node:internal/modules/cjs/loader:1226:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1280:10)
    at Module.load (node:internal/modules/cjs/loader:1089:32)
    at Module._load (node:internal/modules/cjs/loader:930:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47 {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/home/oaie/.solid/.bashlibconfig'
}

Node.js v18.14.0
```